### PR TITLE
Add habitat metadata

### DIFF
--- a/in_text/text_06_habitat.yml
+++ b/in_text/text_06_habitat.yml
@@ -1211,17 +1211,6 @@ entities:
         data-max: NA
         data-units: days
 
-purpose: Fisheries biology, limnological research, and climate science.
-start-date: 19791201
-end-date: 20181231
-
-update: none planned
-themekeywords: ["machine learning", "deep learning", "hybrid modeling", "water","temperature", "temperate lakes","reservoirs","modeling","climate change","thermal profiles"]
-
-usage-rules: >-
-  These data are open access usable via creative commons as long as original data providers are acknowledged
-descgeog: "Lake polygons as defined by the national hydrography dataset high resolution"
-data-publisher: U.S. Geological Survey
 indirect-spatial: U.S.A.
 latitude-res: 0.00001
 longitude-res: 0.00001

--- a/in_text/text_06_habitat.yml
+++ b/in_text/text_06_habitat.yml
@@ -1,2 +1,1213 @@
 title: >-
   Process-guided deep learning water temperature predictions: 6 Habitat metrics
+
+build-environment: >-
+  This dataset was generated using the USGS Advanced Research Computing, USGS Yeti Supercomputer (https://doi.org/10.5066/F7D798MJ) and
+  open source tools available in the R programming language (R version 3.6.3 (2020-02-29)).
+  The computing platform for generating data and metadata was x86_64-redhat-linux-gnu.
+  R packages loaded into this environment: purrr, version: 0.3.4; feather, version: 0.3.5; tidyr, version: 1.1.2;
+  dplyr, version: 1.0.2; jsonlite, version: 1.7.1; readr, version: 1.4.0; sbtools, version: 1.1.12;
+  scipiper, version: 0.0.23; remake, version: 0.3.0.
+
+# ----supporting publications----
+cross-cites:
+  -
+    authors: ['Luke A. Winslow','Gretchen J.A. Hansen','Jordan S. Read','Michael Notaro']
+    title: >-
+      Large-scale modeled contemporary and future water temperature estimates for 10,774 Midwestern U.S. Lakes
+    pubdate: 2017
+    link: http://dx.doi.org/10.1038/sdata.2017.53
+  -
+    authors: ['Donald A. Wismer', 'Alan E. Christie']
+    title: >-
+      Temperature Relationships of Great Lakes Fishes: A Data Compilation
+    pubdate: 1987
+    link: http://www.glfc.org/pubs/SpecialPubs/Sp87_3.pdf
+  -
+    authors: ['Wolf-Dieter N. Busch', 'Russell L. Scholl', 'Wilbur L. Hartman']
+    title: >-
+      Environmental factors affecting the strength of walleye (Stizostedion
+      vitreum vitreum) year-classes in western Lake Erie, 1960-70
+    pubdate: 1975
+    link: https://doi.org/10.1139/f75-207
+  -
+    authors: ['Charles P. Madenjian', 'Jeffrey T. Tyson', 'Roger L. Knight', 'Mark W. Kershner', 'Michael J. Hansen']
+    title: >-
+      First-year growth, recruitment, and maturity of walleyes in western Lake Erie
+    pubdate: 1996
+    link: https://doi.org/10.1577/1548-8659(1996)125<0821:FYGRAM>2.3.CO;2
+  -
+    authors: ['Xing Fang', 'Heinz G, Stefan', 'John G. Eaton', 'J. Howard McCormick', 'Shoeb R. Alam']
+    title: >-
+      Simulation of thermal/dissolved oxygen habitat for fishes in lakes under different
+      climate scenarios: Part 1. Cool-water fish in the contiguous US
+    pubdate: 2004
+    link: https://doi.org/10.1016/S0304-3800(03)00282-5
+  -
+    authors: ['Gavin C. Christie', 'Henry A. Regier']
+    title: >-
+      Measures of optimal thermal habitat and their relationship to yields for four commercial fish species
+    pubdate: 1988
+    link: https://doi.org/10.1139/f88-036
+  -
+    authors: ['Timothy J. Cline', 'Val Bennington', 'James F. Kitchell']
+    title: >-
+      Climate change expands the spatial extent and duration of preferred thermal habitat for Lake Superior fishes
+    pubdate: 2013
+    link: https://doi.org/10.1371/journal.pone.0062279
+  -
+    authors: ['J.M. Casselman']
+    title: >-
+      Effects of temperature, global extremes, and climate change on year-class production
+      of warmwater, coolwater, and coldwater fishes in the Great Lakes Basin
+    pubdate: 2002
+    # Behind paywall in symposium proceedings, so not including in final metadata
+    # link: https://fisheries.org/bookstore/all-titles/afs-symposia/x54032xm/
+  -
+    authors: ['Charles C. Coutant']
+    title: >-
+      Compilation of temperature preference data
+    pubdate: 1977
+    link: https://doi.org/10.1139/f77-115
+  -
+    authors: ['John G. Eaton', 'J. Howard McCormick', 'B.E. Goodno', "D.G. O'Brien", 'Heinz G. Stefan', 'M. Hondzo', 'Robert M. Scheller']
+    title: >-
+      A field information-based system for estimating fish temperature tolerances
+    pubdate: 1995
+    link: https://doi.org/10.1577/1548-8446(1995)020<0010:AFISFE>2.0.CO;2
+  -
+    authors: ['Jordan S. Read', 'David P. Hamilton', 'Ian D. Jones', 'Kohji Muraoka', 'Luke A. Winslow', 'Ryan Kroiss', 'Chin H. Wu', 'Evelyn Gaiser']
+    title: >-
+      Derivation of lake mixing and stratification indices from high-resolution lake buoy data
+    pubdate: 2011
+    link: https://doi.org/10.1016/j.envsoft.2011.05.006
+  -
+    authors: ['USGS Advanced Research Computing']
+    title: >-
+       USGS Yeti Supercomputer
+    pubdate: 2019
+    link: https://doi.org/10.5066/F7D798MJ
+
+process-date: !expr format(Sys.time(),'%Y%m%d')
+file-format: >-
+  two comma-delimited text files
+
+entities:
+  # Copied from mntoha-data-release
+  -
+    data-name: 6_{model}_annual_metrics.csv
+    data-description: >-
+      A csv file containing annual summaries of thermal metrics based on modeled temperatures. {model} is either "glm2pb0"
+      for the uncalibrated Process-Based model outputs or "glm2pball" for the calibrated Process-Based model outputs.
+    attributes:
+      -
+        attr-label: site_id
+        attr-def: >-
+          Lake identification number for this dataset. Is the Prmnn_I from NHD high-res prefixed with source, as "nhdhr_{Prmnn_I}"
+        attr-defs: >-
+          http://nhd.usgs.gov/
+        data-min: NA
+        data-max: NA
+        data-units: NA
+      -
+        attr-label: year
+        attr-def: Year of the summarized temperature predictions
+        attr-defs: This data release
+        data-min: 1980
+        data-max: 2018
+        data-units: NA
+      -
+        attr-label: peak_temp
+        attr-def: Maximum observed surface temperature
+        attr-defs: Winslow et al. 2017
+        data-min: NA
+        data-max: NA
+        data-units: degrees C
+      -
+        attr-label: peak_temp_dt
+        attr-def: Date of maximum observed surface temperature
+        attr-defs: This data release
+        data-min: NA
+        data-max: NA
+        data-units: NA
+      -
+        attr-label: ice_on_date
+        attr-def: Date of ice-on
+        attr-defs: This data release
+        data-min: NA
+        data-max: NA
+        data-units: NA
+      -
+        attr-label: ice_off_date
+        attr-def: Date of ice-off
+        attr-defs: This data release
+        data-min: NA
+        data-max: NA
+        data-units: NA
+      -
+        attr-label: winter_dur_0_4
+        attr-def: >-
+          Number of days, beginning October 30 of the previous year and running through June
+          of the given year, that surface water is <4 degrees C
+        attr-defs: Winslow et al. 2017
+        data-min: NA
+        data-max: NA
+        data-units: days
+      -
+        attr-label: coef_var_31_60
+        attr-def: Coefficient of Variation of surface temperature from 30-60 days post ice off
+        attr-defs: >-
+          This calculation is the same as Winslow et al. 2017, but that one wasn't named
+          intuitively (`coef_var_30_60` instead of `coef_var_31_60`)
+        data-min: NA
+        data-max: NA
+        data-units: unitless (CV)
+      -
+        attr-label: coef_var_1_30
+        attr-def: Coefficient of Variation of surface temperature up to 30 days post ice-off
+        attr-defs: >-
+          This calculation is the same as Winslow et al. 2017, but that one wasn't named
+          intuitively (`coef_var_0_30` instead of `coef_var_1_30`)
+        data-min: NA
+        data-max: NA
+        data-units: unitless (CV)
+      -
+        attr-label: stratification_onset_yday
+        attr-def: Julian date at which stratification sets up (longest stratified period)
+        attr-defs: Winslow et al. 2017
+        data-min: NA
+        data-max: NA
+        data-units: Julian day
+      -
+        attr-label: stratification_duration
+        attr-def: Duration of stratified period
+        attr-defs: Winslow et al. 2017
+        data-min: NA
+        data-max: NA
+        data-units: days
+      -
+        attr-label: sthermo_depth_mean
+        attr-def: Average thermocline depth in stratified period that is >= 30 days
+        attr-defs: >-
+          This calculation is similar to the one from Winslow et al. 2017, except that it
+          uses the longest duration of stratified days as the stratified period and will
+          return NA for any stratified period less than 30 days.
+        data-min: NA
+        data-max: NA
+        data-units: depth (m)
+      -
+        attr-label: bottom_temp_at_strat
+        attr-def: >-
+          Water temperature 0.1m from lake bottom on day of stratification (as defined
+          by "stratification_onset_yday")
+        attr-defs: >-
+          This calculation is similar to the one from Winslow et al. 2017, except that it
+          will return NA for any stratified period less than 30 days.
+        data-min: NA
+        data-max: NA
+        data-units: degrees C
+      -
+        attr-label: gdd_wtr_{temp}c
+        attr-def: >-
+          Cumulative sum of degrees greater than {temp} for an entire
+          year. {temp} is one of 0, 5, 10.
+        attr-defs: Winslow et al. 2017
+        data-min: NA
+        data-max: NA
+        data-units: degrees C * days
+      -
+        attr-label: schmidt_daily_annual_sum
+        attr-def: Sum of daily Schmidt Stability values for calendar year.
+        attr-defs: Winslow et al. 2017
+        data-min: NA
+        data-max: NA
+        data-units: J/m^2 * days
+      -
+        attr-label: mean_{depth}_JulAugSep
+        attr-def: >-
+          Mean summer (July, August, September) temperature at {depth}. {depth} is
+          either "surf" for surface or "bot" for bottom.
+        attr-defs: Winslow et al. 2017
+        data-min: NA
+        data-max: NA
+        data-units: degrees C
+      -
+        attr-label: max_{depth}_JulAugSep
+        attr-def: >-
+          Maximum summer (July, August, September) temperature at {depth}. {depth} is
+          either "surf" for surface or "bot" for bottom.
+        attr-defs: Winslow et al. 2017
+        data-min: NA
+        data-max: NA
+        data-units: degrees C
+      -
+        attr-label: mean_{depth}_{month}
+        attr-def: >-
+          Mean temperature at {depth} for {month}. {depth} is either "surf" for
+          surface or "bot" for bottom. {month} is the 3 letter abbreviation for one
+          of the 12 months, Jan through Dec.
+        attr-defs: Winslow et al. 2017
+        data-min: NA
+        data-max: NA
+        data-units: degrees C
+      -
+        attr-label: max_{depth}_{month}
+        attr-def: >-
+          Maximum temperature at {depth} for {month}. {depth} is either "surf" for
+          surface or "bot" for bottom. {month} is the 3 letter abbreviation for one
+          of the 12 months, Jan (January) through Dec (December).
+        attr-defs: Winslow et al. 2017
+        data-min: NA
+        data-max: NA
+        data-units: degrees C
+      -
+        attr-label: height_6.4_11.8
+        attr-def: >-
+          Meters of water between 6.4 and 11.8 degrees C.
+          This range is used to denote lower good-growth temperature (cold thermal guild)
+        attr-defs: Eaton et al., 1995
+        data-min: NA
+        data-max: NA
+        data-units: linear distance (m)
+      -
+        attr-label: vol_6.4_11.8
+        attr-def: >-
+          Volume of water between 6.4 and 11.8 degrees C.
+
+        attr-defs: Eaton et al., 1995
+        data-min: NA
+        data-max: NA
+        data-units: volume (m^3*1000)
+      -
+        attr-label: days_6.4_11.8
+        attr-def: >-
+          Days in which there is any part of water column between 6.4 and 11.8 degrees C.
+          This range is used to denote lower good-growth temperature (cold thermal guild)
+        attr-defs: Eaton et al., 1995
+        data-min: NA
+        data-max: NA
+        data-units: days
+
+      -
+        attr-label: height_13.2_18.2
+        attr-def: >-
+          Meters of water between 13.2 and 18.2 degrees C.
+          This range is used to denote lower good-growth temperature (cool thermal guild)
+        attr-defs: Eaton et al., 1995
+        data-min: NA
+        data-max: NA
+        data-units: linear distance (m)
+      -
+        attr-label: vol_13.2_18.2
+        attr-def: >-
+          Volume of water between 13.2 and 18.2 degrees C.
+
+        attr-defs: Eaton et al., 1995
+        data-min: NA
+        data-max: NA
+        data-units: volume (m^3*1000)
+      -
+        attr-label: days_13.2_18.2
+        attr-def: >-
+          Days in which there is any part of water column between 13.2 and 18.2 degrees C.
+          This range is used to denote lower good-growth temperature (cool thermal guild)
+        attr-defs: Eaton et al., 1995
+        data-min: NA
+        data-max: NA
+        data-units: days
+
+      -
+        attr-label: height_17.7_22.5
+        attr-def: >-
+          Meters of water between 17.7 and 22.5 degrees C.
+          This range is used to denote lower good-growth temperature (warm thermal guild)
+        attr-defs: Eaton et al., 1995
+        data-min: NA
+        data-max: NA
+        data-units: linear distance (m)
+      -
+        attr-label: vol_17.7_22.5
+        attr-def: >-
+          Volume of water between 17.7 and 22.5 degrees C.
+
+        attr-defs: Eaton et al., 1995
+        data-min: NA
+        data-max: NA
+        data-units: volume (m^3*1000)
+      -
+        attr-label: days_17.7_22.5
+        attr-def: >-
+          Days in which there is any part of water column between 17.7 and 22.5 degrees C.
+          This range is used to denote lower good-growth temperature (warm thermal guild)
+        attr-defs: Eaton et al., 1995
+        data-min: NA
+        data-max: NA
+        data-units: days
+
+      -
+        attr-label: height_11.5_18.7
+        attr-def: >-
+          Meters of water between 11.5 and 18.7 degrees C.
+          This range is used to denote optimum temperature (cold thermal guild)
+        attr-defs: Eaton et al., 1995
+        data-min: NA
+        data-max: NA
+        data-units: linear distance (m)
+      -
+        attr-label: vol_11.5_18.7
+        attr-def: >-
+          Volume of water between 11.5 and 18.7 degrees C.
+
+        attr-defs: Eaton et al., 1995
+        data-min: NA
+        data-max: NA
+        data-units: volume (m^3*1000)
+      -
+        attr-label: days_11.5_18.7
+        attr-def: >-
+          Days in which there is any part of water column between 11.5 and 18.7 degrees C.
+          This range is used to denote optimum temperature (cold thermal guild)
+        attr-defs: Eaton et al., 1995
+        data-min: NA
+        data-max: NA
+        data-units: days
+
+      -
+        attr-label: height_24_25.7
+        attr-def: >-
+          Meters of water between 24 and 25.7 degrees C.
+          This range is used to denote optimum temperature (cool thermal guild)
+        attr-defs: Eaton et al., 1995
+        data-min: NA
+        data-max: NA
+        data-units: linear distance (m)
+      -
+        attr-label: vol_24_25.7
+        attr-def: >-
+          Volume of water between 24 and 25.7 degrees C.
+
+        attr-defs: Eaton et al., 1995
+        data-min: NA
+        data-max: NA
+        data-units: volume (m^3*1000)
+      -
+        attr-label: days_24_25.7
+        attr-def: >-
+          Days in which there is any part of water column between 24 and 25.7 degrees C.
+          This range is used to denote optimum temperature (cool thermal guild)
+        attr-defs: Eaton et al., 1995
+        data-min: NA
+        data-max: NA
+        data-units: days
+
+      -
+        attr-label: height_27_32
+        attr-def: >-
+          Meters of water between 27 and 32 degrees C.
+          This range is used to denote optimum temperature (warm thermal guild)
+        attr-defs: Eaton et al., 1995
+        data-min: NA
+        data-max: NA
+        data-units: linear distance (m)
+      -
+        attr-label: vol_27_32
+        attr-def: >-
+          Volume of water between 27 and 32 degrees C.
+
+        attr-defs: Eaton et al., 1995
+        data-min: NA
+        data-max: NA
+        data-units: volume (m^3*1000)
+      -
+        attr-label: days_27_32
+        attr-def: >-
+          Days in which there is any part of water column between 27 and 32 degrees C.
+          This range is used to denote optimum temperature (warm thermal guild)
+        attr-defs: Eaton et al., 1995
+        data-min: NA
+        data-max: NA
+        data-units: days
+
+      -
+        attr-label: height_15.5_21.2
+        attr-def: >-
+          Meters of water between 15.5 and 21.2 degrees C.
+          This range is used to denote upper good growth temperature (cold thermal guild)
+        attr-defs: Eaton et al., 1995
+        data-min: NA
+        data-max: NA
+        data-units: linear distance (m)
+      -
+        attr-label: vol_15.5_21.2
+        attr-def: >-
+          Volume of water between 15.5 and 21.2 degrees C.
+
+        attr-defs: Eaton et al., 1995
+        data-min: NA
+        data-max: NA
+        data-units: volume (m^3*1000)
+      -
+        attr-label: days_15.5_21.2
+        attr-def: >-
+          Days in which there is any part of water column between 15.5 and 21.2 degrees C.
+          This range is used to denote upper good growth temperature (cold thermal guild)
+        attr-defs: Eaton et al., 1995
+        data-min: NA
+        data-max: NA
+        data-units: days
+
+      -
+        attr-label: height_27.7_28.8
+        attr-def: >-
+          Meters of water between 27.7 and 28.8 degrees C.
+          This range is used to denote upper good growth temperature (cool thermal guild)
+        attr-defs: Eaton et al., 1995
+        data-min: NA
+        data-max: NA
+        data-units: linear distance (m)
+      -
+        attr-label: vol_27.7_28.8
+        attr-def: >-
+          Volume of water between 27.7 and 28.8 degrees C.
+
+        attr-defs: Eaton et al., 1995
+        data-min: NA
+        data-max: NA
+        data-units: volume (m^3*1000)
+      -
+        attr-label: days_27.7_28.8
+        attr-def: >-
+          Days in which there is any part of water column between 27.7 and 28.8 degrees C.
+          This range is used to denote upper good growth temperature (cool thermal guild)
+        attr-defs: Eaton et al., 1995
+        data-min: NA
+        data-max: NA
+        data-units: days
+
+      -
+        attr-label: height_31.3_34.7
+        attr-def: >-
+          Meters of water between 31.3 and 34.7 degrees C.
+          This range is used to denote upper good growth temperature (warm thermal guild)
+        attr-defs: Eaton et al., 1995
+        data-min: NA
+        data-max: NA
+        data-units: linear distance (m)
+      -
+        attr-label: vol_31.3_34.7
+        attr-def: >-
+          Volume of water between 31.3 and 34.7 degrees C.
+
+        attr-defs: Eaton et al., 1995
+        data-min: NA
+        data-max: NA
+        data-units: volume (m^3*1000)
+      -
+        attr-label: days_31.3_34.7
+        attr-def: >-
+          Days in which there is any part of water column between 31.3 and 34.7 degrees C.
+          This range is used to denote upper good growth temperature (warm thermal guild)
+        attr-defs: Eaton et al., 1995
+        data-min: NA
+        data-max: NA
+        data-units: days
+
+      -
+        attr-label: height_26.6_100
+        attr-def: >-
+          Meters of water between 26.6 and 100 degrees C.
+          This range is used to denote upper lethal temperature (cold thermal guild)
+        attr-defs: Eaton et al., 1995
+        data-min: NA
+        data-max: NA
+        data-units: linear distance (m)
+      -
+        attr-label: vol_26.6_100
+        attr-def: >-
+          Volume of water between 26.6 and 100 degrees C.
+
+        attr-defs: Eaton et al., 1995
+        data-min: NA
+        data-max: NA
+        data-units: volume (m^3*1000)
+      -
+        attr-label: days_26.6_100
+        attr-def: >-
+          Days in which there is any part of water column between 26.6 and 100 degrees C.
+          This range is used to denote upper lethal temperature (cold thermal guild)
+        attr-defs: Eaton et al., 1995
+        data-min: NA
+        data-max: NA
+        data-units: days
+
+      -
+        attr-label: height_32.3_100
+        attr-def: >-
+          Meters of water between 32.3 and 100 degrees C.
+          This range is used to denote upper lethal temperature (cool thermal guild)
+        attr-defs: Eaton et al., 1995
+        data-min: NA
+        data-max: NA
+        data-units: linear distance (m)
+      -
+        attr-label: vol_32.3_100
+        attr-def: >-
+          Volume of water between 32.3 and 100 degrees C.
+
+        attr-defs: Eaton et al., 1995
+        data-min: NA
+        data-max: NA
+        data-units: volume (m^3*1000)
+      -
+        attr-label: days_32.3_100
+        attr-def: >-
+          Days in which there is any part of water column between 32.3 and 100 degrees C.
+          This range is used to denote upper lethal temperature (cool thermal guild)
+        attr-defs: Eaton et al., 1995
+        data-min: NA
+        data-max: NA
+        data-units: days
+      -
+        attr-label: height_36_100
+        attr-def: >-
+          Meters of water between 36 and 100 degrees C.
+          This range is used to denote upper lethal temperature (warm thermal guild)
+        attr-defs: Eaton et al., 1995
+        data-min: NA
+        data-max: NA
+        data-units: linear distance (m)
+      -
+        attr-label: vol_36_100
+        attr-def: >-
+          Volume of water between 36 and 100 degrees C.
+
+        attr-defs: Eaton et al., 1995
+        data-min: NA
+        data-max: NA
+        data-units: volume (m^3*1000)
+      -
+        attr-label: days_36_100
+        attr-def: >-
+          Days in which there is any part of water column between 36 and 100 degrees C.
+          This range is used to denote upper lethal temperature (warm thermal guild)
+        attr-defs: Eaton et al., 1995
+        data-min: NA
+        data-max: NA
+        data-units: days
+      -
+        attr-label: height_12_28
+        attr-def: >-
+          Meters of water between 12 and 28 degrees C.
+          This range is used to denote optimal age 0 thermal habitat
+        attr-defs: Wismer and Christie 1987
+        data-min: NA
+        data-max: NA
+        data-units: linear distance (m)
+      -
+        attr-label: vol_12_28
+        attr-def: >-
+          Volume of water between 12 and 28 degrees C.
+
+        attr-defs: Wismer and Christie 1987
+        data-min: NA
+        data-max: NA
+        data-units: volume (m^3*1000)
+      -
+        attr-label: days_12_28
+        attr-def: >-
+          Days in which there is any part of water column between 12 and 28 degrees C.
+          This range is used to denote optimal age 0 thermal habitat
+        attr-defs: Wismer and Christie 1987
+        data-min: NA
+        data-max: NA
+        data-units: days
+      -
+        attr-label: height_10.6_11.2
+        attr-def: >-
+          Meters of water between 10.6 and 11.2 degrees C.
+          This range is used to denote optimal larval thermal habitat
+        attr-defs: Wismer and Christie 1987
+        data-min: NA
+        data-max: NA
+        data-units: linear distance (m)
+      -
+        attr-label: vol_10.6_11.2
+        attr-def: >-
+          Volume of water between 10.6 and 11.2 degrees C.
+
+        attr-defs: Wismer and Christie 1987
+        data-min: NA
+        data-max: NA
+        data-units: volume (m^3*1000)
+      -
+        attr-label: days_10.6_11.2
+        attr-def: >-
+          Days in which there is any part of water column between 10.6 and 11.2 degrees C.
+          This range is used to denote optimal larval thermal habitat
+        attr-defs: Wismer and Christie 1987
+        data-min: NA
+        data-max: NA
+        data-units: days
+
+      -
+        attr-label: height_18.2_28.2
+        attr-def: >-
+          Meters of water between 18.2 and 28.2 degrees C.
+          This range is used to denote good growth habitat
+        attr-defs: Fang et al. 2004
+        data-min: NA
+        data-max: NA
+        data-units: linear distance (m)
+      -
+        attr-label: vol_18.2_28.2
+        attr-def: >-
+          Volume of water between 18.2 and 28.2 degrees C.
+
+        attr-defs: Fang et al. 2004
+        data-min: NA
+        data-max: NA
+        data-units: volume (m^3*1000)
+      -
+        attr-label: days_18.2_28.2
+        attr-def: >-
+          Days in which there is any part of water column between 18.2 and 28.2 degrees C.
+          This range is used to denote good growth habitat
+        attr-defs: Fang et al. 2004
+        data-min: NA
+        data-max: NA
+        data-units: days
+
+      -
+        attr-label: height_18_22
+        attr-def: >-
+          Meters of water between 18 and 22 degrees C.
+          This range is used to denote optimal age 0 thermal habitat
+        attr-defs: Christie and Regier 1988
+        data-min: NA
+        data-max: NA
+        data-units: linear distance (m)
+      -
+        attr-label: vol_18_22
+        attr-def: >-
+          Volume of water between 18 and 22 degrees C.
+
+        attr-defs: Christie and Regier 1988
+        data-min: NA
+        data-max: NA
+        data-units: volume (m^3*1000)
+      -
+        attr-label: days_18_22
+        attr-def: >-
+          Days in which there is any part of water column between 18 and 22 degrees C.
+          This range is used to denote optimal age 0 thermal habitat
+        attr-defs: Christie and Regier 1988
+        data-min: NA
+        data-max: NA
+        data-units: days
+
+      -
+        attr-label: height_19.3_23.3
+        attr-def: >-
+          Meters of water between 19.3 and 23.3 degrees C.
+          This range is used to denote YOY optimum
+        attr-defs: Wismer and Christie 1987
+        data-min: NA
+        data-max: NA
+        data-units: linear distance (m)
+      -
+        attr-label: vol_19.3_23.3
+        attr-def: >-
+          Volume of water between 19.3 and 23.3 degrees C.
+
+        attr-defs: Wismer and Christie 1987
+        data-min: NA
+        data-max: NA
+        data-units: volume (m^3*1000)
+      -
+        attr-label: days_19.3_23.3
+        attr-def: >-
+          Days in which there is any part of water column between 19.3 and 23.3 degrees C.
+          This range is used to denote YOY optimum
+        attr-defs: Wismer and Christie 1987
+        data-min: NA
+        data-max: NA
+        data-units: days
+
+      -
+        attr-label: height_19_23
+        attr-def: >-
+          Meters of water between 19 and 23 degrees C.
+          This range is used to denote optimal thermal habitat
+        attr-defs: Cline et al. 2013
+        data-min: NA
+        data-max: NA
+        data-units: linear distance (m)
+      -
+        attr-label: vol_19_23
+        attr-def: >-
+          Volume of water between 19 and 23 degrees C.
+
+        attr-defs: Cline et al. 2013
+        data-min: NA
+        data-max: NA
+        data-units: volume (m^3*1000)
+      -
+        attr-label: days_19_23
+        attr-def: >-
+          Days in which there is any part of water column between 19 and 23 degrees C.
+          This range is used to denote optimal thermal habitat
+        attr-defs: Cline et al. 2013
+        data-min: NA
+        data-max: NA
+        data-units: days
+
+      -
+        attr-label: height_20.6_23.2
+        attr-def: >-
+          Meters of water between 20.6 and 23.2 degrees C.
+          This range is used to denote optimal thermal habitat
+        attr-defs: Wismer and Christie 1987
+        data-min: NA
+        data-max: NA
+        data-units: linear distance (m)
+      -
+        attr-label: vol_20.6_23.2
+        attr-def: >-
+          Volume of water between 20.6 and 23.2 degrees C.
+
+        attr-defs: Wismer and Christie 1987
+        data-min: NA
+        data-max: NA
+        data-units: volume (m^3*1000)
+      -
+        attr-label: days_20.6_23.2
+        attr-def: >-
+          Days in which there is any part of water column between 20.6 and 23.2 degrees C.
+          This range is used to denote optimal thermal habitat
+        attr-defs: Wismer and Christie 1987
+        data-min: NA
+        data-max: NA
+        data-units: days
+
+      -
+        attr-label: height_20_30
+        attr-def: >-
+          Meters of water between 20 and 30 degrees C.
+          This range is used to denote larval optimum
+        attr-defs: Wismer and Christie 1987
+        data-min: NA
+        data-max: NA
+        data-units: linear distance (m)
+      -
+        attr-label: vol_20_30
+        attr-def: >-
+          Volume of water between 20 and 30 degrees C.
+
+        attr-defs: Wismer and Christie 1987
+        data-min: NA
+        data-max: NA
+        data-units: volume (m^3*1000)
+      -
+        attr-label: days_20_30
+        attr-def: >-
+          Days in which there is any part of water column between 20 and 30 degrees C.
+          This range is used to denote larval optimum
+        attr-defs: Wismer and Christie 1987
+        data-min: NA
+        data-max: NA
+        data-units: days
+
+      -
+        attr-label: height_21_100
+        attr-def: >-
+          Meters of water between 21 and 100 degrees C.
+          This range is used to denote growing season for YOY
+        attr-defs: Wismer and Christie 1987
+        data-min: NA
+        data-max: NA
+        data-units: linear distance (m)
+      -
+        attr-label: vol_21_100
+        attr-def: >-
+          Volume of water between 21 and 100 degrees C.
+
+        attr-defs: Wismer and Christie 1987
+        data-min: NA
+        data-max: NA
+        data-units: volume (m^3*1000)
+      -
+        attr-label: days_21_100
+        attr-def: >-
+          Days in which there is any part of water column between 21 and 100 degrees C.
+          This range is used to denote growing season for YOY
+        attr-defs: Wismer and Christie 1987
+        data-min: NA
+        data-max: NA
+        data-units: days
+
+      -
+        attr-label: height_22_23
+        attr-def: >-
+          Meters of water between 22 and 23 degrees C.
+          This range is used to denote optimal thermal habitat
+        attr-defs: Casselman 2002
+        data-min: NA
+        data-max: NA
+        data-units: linear distance (m)
+      -
+        attr-label: vol_22_23
+        attr-def: >-
+          Volume of water between 22 and 23 degrees C.
+
+        attr-defs: Casselman 2002
+        data-min: NA
+        data-max: NA
+        data-units: volume (m^3*1000)
+      -
+        attr-label: days_22_23
+        attr-def: >-
+          Days in which there is any part of water column between 22 and 23 degrees C.
+          This range is used to denote optimal thermal habitat
+        attr-defs: Casselman 2002
+        data-min: NA
+        data-max: NA
+        data-units: days
+
+      -
+        attr-label: height_23_31
+        attr-def: >-
+          Meters of water between 23 and 31 degrees C.
+          This range is used to denote juvenile optimum
+        attr-defs: Wismer and Christie 1987
+        data-min: NA
+        data-max: NA
+        data-units: linear distance (m)
+      -
+        attr-label: vol_23_31
+        attr-def: >-
+          Volume of water between 23 and 31 degrees C.
+
+        attr-defs: Wismer and Christie 1987
+        data-min: NA
+        data-max: NA
+        data-units: volume (m^3*1000)
+      -
+        attr-label: days_23_31
+        attr-def: >-
+          Days in which there is any part of water column between 23 and 31 degrees C.
+          This range is used to denote juvenile optimum
+        attr-defs: Wismer and Christie 1987
+        data-min: NA
+        data-max: NA
+        data-units: days
+
+      -
+        attr-label: height_25_29
+        attr-def: >-
+          Meters of water between 25 and 29 degrees C.
+          This range is used to denote larval optimum
+        attr-defs: Wismer and Christie 1987
+        data-min: NA
+        data-max: NA
+        data-units: linear distance (m)
+      -
+        attr-label: vol_25_29
+        attr-def: >-
+          Volume of water between 25 and 29 degrees C.
+
+        attr-defs: Wismer and Christie 1987
+        data-min: NA
+        data-max: NA
+        data-units: volume (m^3*1000)
+      -
+        attr-label: days_25_29
+        attr-def: >-
+          Days in which there is any part of water column between 25 and 29 degrees C.
+          This range is used to denote larval optimum
+        attr-defs: Wismer and Christie 1987
+        data-min: NA
+        data-max: NA
+        data-units: days
+
+      -
+        attr-label: height_26.2_32
+        attr-def: >-
+          Meters of water between 26.2 and 32 degrees C.
+          This range is used to denote good growth habitat
+        attr-defs: Countant 1977
+        data-min: NA
+        data-max: NA
+        data-units: linear distance (m)
+      -
+        attr-label: vol_26.2_32
+        attr-def: >-
+          Volume of water between 26.2 and 32 degrees C.
+
+        attr-defs: Countant 1977
+        data-min: NA
+        data-max: NA
+        data-units: volume (m^3*1000)
+      -
+        attr-label: days_26.2_32
+        attr-def: >-
+          Days in which there is any part of water column between 26.2 and 32 degrees C.
+          This range is used to denote good growth habitat
+        attr-defs: Countant 1977
+        data-min: NA
+        data-max: NA
+        data-units: days
+
+      -
+        attr-label: height_26_28
+        attr-def: >-
+          Meters of water between 26 and 28 degrees C.
+          This range is used to denote subadult optimum
+        attr-defs: Wismer and Christie 1987
+        data-min: NA
+        data-max: NA
+        data-units: linear distance (m)
+      -
+        attr-label: vol_26_28
+        attr-def: >-
+          Volume of water between 26 and 28 degrees C.
+
+        attr-defs: Wismer and Christie 1987
+        data-min: NA
+        data-max: NA
+        data-units: volume (m^3*1000)
+      -
+        attr-label: days_26_28
+        attr-def: >-
+          Days in which there is any part of water column between 26 and 28 degrees C.
+          This range is used to denote subadult optimum
+        attr-defs: Wismer and Christie 1987
+        data-min: NA
+        data-max: NA
+        data-units: days
+
+      -
+        attr-label: height_26_30
+        attr-def: >-
+          Meters of water between 26 and 30 degrees C.
+          This range is used to denote adult optimum
+        attr-defs: Wismer and Christie 1987
+        data-min: NA
+        data-max: NA
+        data-units: linear distance (m)
+      -
+        attr-label: vol_26_30
+        attr-def: >-
+          Volume of water between 26 and 30 degrees C.
+
+        attr-defs: Wismer and Christie 1987
+        data-min: NA
+        data-max: NA
+        data-units: volume (m^3*1000)
+      -
+        attr-label: days_26_30
+        attr-def: >-
+          Days in which there is any part of water column between 26 and 30 degrees C.
+          This range is used to denote adult optimum
+        attr-defs: Wismer and Christie 1987
+        data-min: NA
+        data-max: NA
+        data-units: days
+
+      -
+        attr-label: height_28_29
+        attr-def: >-
+          Meters of water between 28 and 29 degrees C.
+          This range is used to denote juvenile optimum
+        attr-defs: Wismer and Christie 1987
+        data-min: NA
+        data-max: NA
+        data-units: linear distance (m)
+      -
+        attr-label: vol_28_29
+        attr-def: >-
+          Volume of water between 28 and 29 degrees C.
+
+        attr-defs: Wismer and Christie 1987
+        data-min: NA
+        data-max: NA
+        data-units: volume (m^3*1000)
+      -
+        attr-label: days_28_29
+        attr-def: >-
+          Days in which there is any part of water column between 28 and 29 degrees C.
+          This range is used to denote juvenile optimum
+        attr-defs: Wismer and Christie 1987
+        data-min: NA
+        data-max: NA
+        data-units: days
+
+      -
+        attr-label: height_28_32
+        attr-def: >-
+          Meters of water between 28 and 32 degrees C.
+          This range is used to denote juvenile optimum
+        attr-defs: Wismer and Christie 1987
+        data-min: NA
+        data-max: NA
+        data-units: linear distance (m)
+      -
+        attr-label: vol_28_32
+        attr-def: >-
+          Volume of water between 28 and 32 degrees C.
+
+        attr-defs: Wismer and Christie 1987
+        data-min: NA
+        data-max: NA
+        data-units: volume (m^3*1000)
+      -
+        attr-label: days_28_32
+        attr-def: >-
+          Days in which there is any part of water column between 28 and 32 degrees C.
+          This range is used to denote juvenile optimum
+        attr-defs: Wismer and Christie 1987
+        data-min: NA
+        data-max: NA
+        data-units: days
+
+      -
+        attr-label: height_29_100
+        attr-def: >-
+          Meters of water between 29 and 100 degrees C.
+          This range is used to denote lethal habitat
+        attr-defs: Fang et al. 2004
+        data-min: NA
+        data-max: NA
+        data-units: linear distance (m)
+      -
+        attr-label: vol_29_100
+        attr-def: >-
+          Volume of water between 29 and 100 degrees C.
+
+        attr-defs: Fang et al. 2004
+        data-min: NA
+        data-max: NA
+        data-units: volume (m^3*1000)
+      -
+        attr-label: days_29_100
+        attr-def: >-
+          Days in which there is any part of water column between 29 and 100 degrees C.
+          This range is used to denote lethal habitat
+        attr-defs: Fang et al. 2004
+        data-min: NA
+        data-max: NA
+        data-units: days
+
+      -
+        attr-label: height_30_31
+        attr-def: >-
+          Meters of water between 30 and 31 degrees C.
+          This range is used to denote adult optimum
+        attr-defs: Wismer and Christie 1987
+        data-min: NA
+        data-max: NA
+        data-units: linear distance (m)
+      -
+        attr-label: vol_30_31
+        attr-def: >-
+          Volume of water between 30 and 31 degrees C.
+
+        attr-defs: Wismer and Christie 1987
+        data-min: NA
+        data-max: NA
+        data-units: volume (m^3*1000)
+      -
+        attr-label: days_30_31
+        attr-def: >-
+          Days in which there is any part of water column between 30 and 31 degrees C.
+          This range is used to denote adult optimum
+        attr-defs: Wismer and Christie 1987
+        data-min: NA
+        data-max: NA
+        data-units: days
+      -
+        attr-label: spring_days_in_10.5_15.5
+        attr-def: >-
+          Duration of optimal incubation period where surface temperature
+          is between 10.5-15.5 degrees C (Spring only)
+        attr-defs: Wismer and Christie 1987
+        data-min: NA
+        data-max: NA
+        data-units: days before June 1
+      -
+        attr-label: post_ice_warm_rate
+        attr-def: >-
+          Average change in surface temp (degrees C per day) 30 days post ice off
+        attr-defs: Busch et al. 1975; Madenijan et al. 1996
+        data-min: NA
+        data-max: NA
+        data-units: degrees C per day
+      -
+        attr-label: date_over_{temp}
+        attr-def: >-
+          Date where average surface temperature reaches {temp} degrees C. {temp} is
+          one of 8.9 (date of spawning temp), 16.7 (hatch date), 18 (date of spawning
+          temp for bass), or 21 (date of spawning temp for bass).
+        attr-defs: Wismer and Christie 1987
+        data-min: NA
+        data-max: NA
+        data-units: Julian day
+      -
+        attr-label: SmetaTopD_mean
+        attr-def: Mean epilmnion meters during the longest stratified period
+        attr-defs: Read et al. 2011
+        data-min: NA
+        data-max: NA
+        data-units: linear distance (m)
+      -
+        attr-label: SmetaBotD_mean
+        attr-def: Mean hypolimnion meters during the longest stratified period
+        attr-defs: Read et al. 2011
+        data-min: NA
+        data-max: NA
+        data-units: linear distance (m)
+      -
+        attr-label: mean_epi_vol
+        attr-def: Mean epilmnion volume during longest stratified period
+        attr-defs: This data release
+        data-min: NA
+        data-max: NA
+        data-units: volume (m^3*1000)
+      -
+        attr-label: mean_hyp_vol
+        attr-def: Mean hypolimnion volume during longest stratified period
+        attr-defs: This data release
+        data-min: NA
+        data-max: NA
+        data-units: volume (m^3*1000)
+      -
+        attr-label: mean_epi_hypo_ratio
+        attr-def: Mean epilmnion volume divided by mean hypolimnion volume
+        attr-defs: This data release
+        data-min: NA
+        data-max: NA
+        data-units: unitless (ratio)
+      -
+        attr-label: open_water_duration
+        attr-def: >-
+          Number of days between ice-on and ice-off. If `NA`, the open water
+          period could not be calculated because there was not an ice-off or
+          ice-on date for that year.
+        attr-defs: This data release
+        data-min: NA
+        data-max: NA
+        data-units: days
+
+purpose: Fisheries biology, limnological research, and climate science.
+start-date: 19791201
+end-date: 20181231
+
+update: none planned
+themekeywords: ["machine learning", "deep learning", "hybrid modeling", "water","temperature", "temperate lakes","reservoirs","modeling","climate change","thermal profiles"]
+
+usage-rules: >-
+  These data are open access usable via creative commons as long as original data providers are acknowledged
+descgeog: "Lake polygons as defined by the national hydrography dataset high resolution"
+data-publisher: U.S. Geological Survey
+indirect-spatial: U.S.A.
+latitude-res: 0.00001
+longitude-res: 0.00001

--- a/in_text/text_06_habitat.yml
+++ b/in_text/text_06_habitat.yml
@@ -132,14 +132,21 @@ entities:
         data-units: NA
       -
         attr-label: ice_on_date
-        attr-def: Date of ice-on
+        attr-def: >-
+          Date of ice-on for the current year's winter season. This could mean that the
+          date actually occurs in the previous year (e.g. ice-on for winter of 2017 happened
+          in December of 2016). This definition of ice-on is consistent with the Wisconsin
+          State Climatology Office's use of ice-on and ice-off dates by winter season. If
+          this value is `NA`, it means that no ice formed during that winter season.
         attr-defs: This data release
         data-min: NA
         data-max: NA
         data-units: NA
       -
         attr-label: ice_off_date
-        attr-def: Date of ice-off
+        attr-def: >-
+          Date of ice-off for the current year's winter season. If this
+          value is `NA`, it means that no ice formed during that winter season.
         attr-defs: This data release
         data-min: NA
         data-max: NA
@@ -1189,9 +1196,11 @@ entities:
       -
         attr-label: open_water_duration
         attr-def: >-
-          Number of days between ice-on and ice-off. If `NA`, the open water
-          period could not be calculated because there was not an ice-off or
-          ice-on date for that year.
+          Number of days between ice-off for this year's winter season and ice-on
+          for the next year's winter season. If `NA`, the open water period could
+          not be calculated because there was either not an ice-off date for this
+          year's winter season or an ice-on date for the next year's winter season
+          or both were missing.
         attr-defs: This data release
         data-min: NA
         data-max: NA

--- a/in_text/text_06_habitat.yml
+++ b/in_text/text_06_habitat.yml
@@ -1,6 +1,11 @@
 title: >-
   Process-guided deep learning water temperature predictions: 6 Habitat metrics
 
+abstract: >-
+  This dataset summarized a collection of annual thermal metrics to characterize lake temperature impacts on 
+  fish habitat for 7,144 lakes from uncalibrated models (PB0) and 449 from calibrated models (PBALL). The dataset
+  includes over 172 annual thermal metrics.
+
 build-environment: >-
   This dataset was generated using the USGS Advanced Research Computing, USGS Yeti Supercomputer (https://doi.org/10.5066/F7D798MJ) and
   open source tools available in the R programming language (R version 3.6.3 (2020-02-29)).


### PR DESCRIPTION
All of the habitat metadata! Mostly copied from mntoha. It does include recent changes to `ice_on_date`, `ice_off_date`, and `open_water_duration` as added via https://github.com/USGS-R/mntoha-data-release/pull/46.

~Is there a `larger-cites` needed for this release [like mntoha has](https://github.com/USGS-R/mntoha-data-release/blob/master/in_text/text_07_habitat.yml#L18-L23)?~ already asked this question in #20 and don't need

This closes #20. Once it & #24 are merged, @lindsayplatt can complete the last step in #23.